### PR TITLE
Balance collapse fixes

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/storage/RatesRepository.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/storage/RatesRepository.kt
@@ -12,7 +12,7 @@ class RatesRepository(private val appDatabase: AppDatabase) : IRateStorage {
     private val executor = Executors.newSingleThreadExecutor()
 
     override fun latestRateObservable(coinCode: CoinCode, currencyCode: String): Flowable<Rate> {
-        return appDatabase.ratesDao().getLatestRate(coinCode, currencyCode)
+        return appDatabase.ratesDao().getLatestRate(coinCode, currencyCode).distinctUntilChanged()
     }
 
     override fun rateObservable(coinCode: CoinCode, currencyCode: String, timestamp: Long): Flowable<List<Rate>> {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.support.v4.content.ContextCompat
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
+import android.support.v7.widget.SimpleItemAnimator
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -99,6 +100,7 @@ class BalanceFragment : android.support.v4.app.Fragment(), CoinsAdapter.Listener
         coinsAdapter.viewDelegate = viewModel.delegate
         recyclerCoins.adapter = coinsAdapter
         recyclerCoins.layoutManager = LinearLayoutManager(context)
+        (recyclerCoins.itemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false
 
         manageCoins.setOnSingleClickListener { viewModel.delegate.openManageCoins() }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/viewHelpers/ValueFormatter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/viewHelpers/ValueFormatter.kt
@@ -69,7 +69,7 @@ object ValueFormatter {
         value = Math.abs(value)
 
         var result: String = when {
-            value < FIAT_SMALL_NUMBER_EDGE -> "0.01"
+            value > 0 && value < FIAT_SMALL_NUMBER_EDGE -> "0.01"
             else -> {
                 val formatter = currencyFormatter
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/viewHelpers/ValueFormatter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/viewHelpers/ValueFormatter.kt
@@ -69,7 +69,8 @@ object ValueFormatter {
         value = Math.abs(value)
 
         var result: String = when {
-            value > 0 && value < FIAT_SMALL_NUMBER_EDGE -> "0.01"
+            value == 0.0 -> "0"
+            value < FIAT_SMALL_NUMBER_EDGE -> "0.01"
             else -> {
                 val formatter = currencyFormatter
 

--- a/app/src/main/res/layout/view_holder_coin.xml
+++ b/app/src/main/res/layout/view_holder_coin.xml
@@ -98,6 +98,7 @@
         android:layout_marginStart="4dp"
         android:layout_marginTop="14dp"
         android:orientation="horizontal"
+        android:gravity="bottom"
         >
 
         <TextView

--- a/app/src/test/java/io/horizontalsystems/bankwallet/viewHelpers/ValueFormatterTest.kt
+++ b/app/src/test/java/io/horizontalsystems/bankwallet/viewHelpers/ValueFormatterTest.kt
@@ -21,6 +21,7 @@ class ValueFormatterTest {
         assertCurrencyFormatter(1203.903, "$ 1,204")
         assertCurrencyFormatter(0.0003903, "$ 0.01")
         assertCurrencyFormatter(-0.0003903, "- $ 0.01")
+        assertCurrencyFormatter(0.0, "$ 0")
     }
 
     @Test


### PR DESCRIPTION
- Fix exchange rate move on rate update in Coin Wallets
- Disable default animation on item binding for Coin Wallets
Partially fix #473 