### PR TITLE
Confirmation dialog updates

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/Interfaces.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/Interfaces.kt
@@ -166,6 +166,7 @@ interface IPinManager {
 }
 
 interface ILockManager {
+    val lockStateUpdatedSignal: PublishSubject<Unit>
     var isLocked: Boolean
     fun lock()
     fun onUnlock()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/LockManager.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/LockManager.kt
@@ -5,15 +5,22 @@ import io.horizontalsystems.bankwallet.core.ILockManager
 import io.horizontalsystems.bankwallet.core.ISecuredStorage
 import io.horizontalsystems.bankwallet.modules.pin.PinModule
 import io.horizontalsystems.bankwallet.viewHelpers.DateHelper
+import io.reactivex.subjects.PublishSubject
 import java.util.*
 
 class LockManager(
         private val securedStorage: ISecuredStorage,
-        private val authManager: AuthManager): ILockManager {
+        private val authManager: AuthManager) : ILockManager {
 
     private val lockTimeout: Double = 60.0
 
+    override val lockStateUpdatedSignal: PublishSubject<Unit> = PublishSubject.create()
+
     override var isLocked: Boolean = false
+        set(value) {
+            field = value
+            lockStateUpdatedSignal.onNext(Unit)
+        }
 
     override fun didEnterBackground() {
         if (!authManager.isLoggedIn || isLocked) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/BackupInteractor.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/BackupInteractor.kt
@@ -34,7 +34,7 @@ class BackupInteractor(
     }
 
     override fun shouldShowTermsConfirmation(): Boolean {
-        return !localStorage.iUnderstand
+        return !localStorage.iUnderstand || !wordsManager.isBackedUp
     }
 
     override fun validate(confirmationWords: HashMap<Int, String>) {
@@ -48,8 +48,8 @@ class BackupInteractor(
             }
 
             if (valid) {
-                wordsManager.isBackedUp = true
                 delegate?.didValidateSuccess()
+                wordsManager.isBackedUp = true
             } else {
                 delegate?.didValidateFailure()
             }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsActivity.kt
@@ -121,6 +121,10 @@ class SecuritySettingsActivity : BaseActivity(), BottomConfirmAlert.Listener {
             startActivity(intent)
         })
 
+        viewModel.showPinUnlockLiveEvent.observe(this, Observer {
+            PinModule.startForUnlock()
+        })
+
     }
 
     override fun onConfirmationSuccess() {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsInteractor.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsInteractor.kt
@@ -1,21 +1,25 @@
 package io.horizontalsystems.bankwallet.modules.settings.security
 
 import io.horizontalsystems.bankwallet.core.ILocalStorage
+import io.horizontalsystems.bankwallet.core.ILockManager
 import io.horizontalsystems.bankwallet.core.ISystemInfoManager
 import io.horizontalsystems.bankwallet.core.IWordsManager
 import io.horizontalsystems.bankwallet.core.managers.AuthManager
 import io.horizontalsystems.bankwallet.entities.BiometryType
+import io.reactivex.disposables.Disposable
 
 class SecuritySettingsInteractor(
         private val authManager: AuthManager,
         private val wordsManager: IWordsManager,
         private val localStorage: ILocalStorage,
-        private val systemInfoManager: ISystemInfoManager): SecuritySettingsModule.ISecuritySettingsInteractor {
+        private val systemInfoManager: ISystemInfoManager,
+        private val lockManager: ILockManager): SecuritySettingsModule.ISecuritySettingsInteractor {
 
     var delegate: SecuritySettingsModule.ISecuritySettingsInteractorDelegate? = null
+    private var lockStateUpdateDisposable: Disposable? = null
 
     init {
-        wordsManager.backedUpSignal.subscribe {
+        val backupDisposable = wordsManager.backedUpSignal.subscribe {
             onUpdateBackedUp()
         }
     }
@@ -26,7 +30,7 @@ class SecuritySettingsInteractor(
         }
     }
 
-    override var biometryType: BiometryType = BiometryType.NONE
+    override val biometryType: BiometryType
         get() = systemInfoManager.biometryType
 
     override var isBackedUp: Boolean = wordsManager.isBackedUp
@@ -42,5 +46,16 @@ class SecuritySettingsInteractor(
     override fun unlinkWallet() {
         authManager.logout()
         delegate?.didUnlinkWallet()
+    }
+
+    override fun didTapOnBackupWallet() {
+        delegate?.accessIsRestricted()
+        lockStateUpdateDisposable?.dispose()
+        lockStateUpdateDisposable = lockManager.lockStateUpdatedSignal.subscribe {
+            if (!lockManager.isLocked) {
+                delegate?.openBackupWallet()
+                lockStateUpdateDisposable?.dispose()
+            }
+        }
     }
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsModule.kt
@@ -26,21 +26,25 @@ object SecuritySettingsModule {
 
     interface ISecuritySettingsInteractor {
         var isBackedUp: Boolean
-        var biometryType: BiometryType
+        val biometryType: BiometryType
         fun getBiometricUnlockOn(): Boolean
         fun setBiometricUnlockOn(biometricUnlockOn: Boolean)
         fun unlinkWallet()
+        fun didTapOnBackupWallet()
     }
 
     interface ISecuritySettingsInteractorDelegate {
         fun didBackup()
         fun didUnlinkWallet()
+        fun openBackupWallet()
+        fun accessIsRestricted()
     }
 
     interface ISecuritySettingsRouter{
         fun showEditPin()
         fun showBackupWallet()
         fun showRestoreWallet()
+        fun showPinUnlock()
     }
 
     fun start(context: Context) {
@@ -49,7 +53,7 @@ object SecuritySettingsModule {
     }
 
     fun init(view: SecuritySettingsViewModel, router: ISecuritySettingsRouter) {
-        val interactor = SecuritySettingsInteractor(App.authManager, App.wordsManager, App.localStorage, App.systemInfoManager)
+        val interactor = SecuritySettingsInteractor(App.authManager, App.wordsManager, App.localStorage, App.systemInfoManager, App.lockManager)
         val presenter = SecuritySettingsPresenter(router, interactor)
 
         view.delegate = presenter

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsPresenter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsPresenter.kt
@@ -25,6 +25,14 @@ class SecuritySettingsPresenter(
     }
 
     override fun didTapBackupWallet() {
+        interactor.didTapOnBackupWallet()
+    }
+
+    override fun accessIsRestricted() {
+        router.showPinUnlock()
+    }
+
+    override fun openBackupWallet() {
         router.showBackupWallet()
     }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsViewModel.kt
@@ -18,6 +18,7 @@ class SecuritySettingsViewModel: ViewModel(), SecuritySettingsModule.ISecuritySe
     val openBackupWalletLiveEvent = SingleLiveEvent<Unit>()
     val openRestoreWalletLiveEvent = SingleLiveEvent<Unit>()
     val reloadAppLiveEvent = SingleLiveEvent<Unit>()
+    val showPinUnlockLiveEvent = SingleLiveEvent<Unit>()
 
     fun init() {
         SecuritySettingsModule.init(this, this)
@@ -54,5 +55,9 @@ class SecuritySettingsViewModel: ViewModel(), SecuritySettingsModule.ISecuritySe
 
     override fun reloadApp() {
         reloadAppLiveEvent.call()
+    }
+
+    override fun showPinUnlock() {
+        showPinUnlockLiveEvent.call()
     }
 }


### PR DESCRIPTION
Close #145
- Show confirmation dialog on Backup words validation if user hasn't backup them before
- Show PIN unlock when user taps on Backup wallet words in Settings