### PR TITLE
Increase the PIN timeout for android secure storage access to 24 hours

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -124,7 +124,7 @@ dependencies {
     releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.6.2'
 
     // BitcoinKit
-    implementation 'com.github.horizontalsystems:bitcoin-kit-android:2bae8ba'
+    implementation 'com.github.horizontalsystems:bitcoin-kit-android:937ccee'
 
     // EthereumKit
     implementation 'com.github.horizontalsystems:ethereum-kit-android:16daeb1'

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/security/KeyStoreWrapper.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/security/KeyStoreWrapper.kt
@@ -16,7 +16,7 @@ class KeyStoreWrapper {
         private const val BLOCK_MODE = KeyProperties.BLOCK_MODE_CBC
         private const val PADDING = KeyProperties.ENCRYPTION_PADDING_PKCS7
 
-        private const val AUTH_DURATION_SEC = 1800 //30 minute
+        private const val AUTH_DURATION_SEC = 86400 //24 hours in seconds (24x60x60)
     }
 
     private val keyStore: KeyStore = getAndroidKeyStore()


### PR DESCRIPTION
Close #767