### PR TITLE
Fix AlertDialog width for landscape

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -299,6 +299,7 @@
         <item name="android:backgroundDimAmount">0.7</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowMinWidthMinor">85%</item>
+        <item name="android:windowMinWidthMajor">65%</item>
         <item name="android:windowSoftInputMode">adjustResize|stateHidden</item>
     </style>
 


### PR DESCRIPTION
When using a device in landscape mode, alerts width are very small.
Example below, on a 8" tablet

Before
![Before](https://user-images.githubusercontent.com/46036035/56322436-f95eb900-6160-11e9-939f-78490f7399e7.jpeg)

After this fix
![After](https://user-images.githubusercontent.com/46036035/56322435-f95eb900-6160-11e9-9092-6daad8314682.jpeg)
